### PR TITLE
Fix getRandomOTP function

### DIFF
--- a/lib/email_otp.dart
+++ b/lib/email_otp.dart
@@ -208,7 +208,27 @@ class EmailOTP {
     });
   }
 
+  @visibleForTesting
+  static String testableGetRandomOTP() => _getRandomOTP();
+
   static String _getRandomOTP() {
-    return (Random().nextInt(900000) + 100000).toString();
+    final random = Random();
+    final otpBuffer = StringBuffer();
+    for (var i = 0; i < (_otpLength ?? 1); i++) {
+      switch (_otpType) {
+        case OTPType.alpha:
+          otpBuffer.write(String.fromCharCode(random.nextInt(26) + 65));
+          break;
+        case OTPType.alphaNumeric:
+          otpBuffer.write(random.nextBool()
+              ? String.fromCharCode(random.nextInt(26) + 65)
+              : random.nextInt(10).toString());
+          break;
+        case OTPType.numeric:
+        default:
+          otpBuffer.write(random.nextInt(10).toString());
+      }
+    }
+    return otpBuffer.toString();
   }
 }

--- a/test/_test.dart
+++ b/test/_test.dart
@@ -26,4 +26,41 @@ void main() {
     }
     expect(isSent, true);
   });
+
+  group('Random OTP', () {
+    test('getRandomOTP generates OTP of correct length', () {
+      EmailOTP.config(otpLength: 6);
+
+      String otp = EmailOTP.testableGetRandomOTP();
+
+      EmailOTP.config(otpLength: 8);
+
+      String otp2 = EmailOTP.testableGetRandomOTP();
+
+      EmailOTP.config(otpLength: 12);
+
+      String otp3 = EmailOTP.testableGetRandomOTP();
+
+      expect(otp.length, 6);
+      expect(otp2.length, 8);
+      expect(otp3.length, 12);
+    });
+
+    test('getRandomOTP generates numeric OTP', () {
+      EmailOTP.config(otpLength: 6);
+
+      String otp = EmailOTP.testableGetRandomOTP();
+
+      expect(int.tryParse(otp), isNotNull);
+    });
+
+    test('getRandomOTP generates different OTPs on subsequent calls', () {
+      EmailOTP.config(otpLength: 6);
+
+      String otp1 = EmailOTP.testableGetRandomOTP();
+      String otp2 = EmailOTP.testableGetRandomOTP();
+
+      expect(otp1, isNot(equals(otp2)));
+    });
+  });
 }


### PR DESCRIPTION
This pull request includes changes to the `EmailOTP` class in `lib/email_otp.dart` and updates to the test cases in `test/_test.dart`. The main focus of these changes is to enhance the generation of OTPs by supporting different OTP types and lengths, and to add corresponding tests.

Enhancements to OTP generation:

* [`lib/email_otp.dart`](diffhunk://#diff-c5fb6fcb996defe7f2bb88fe40b28d003da49d4379d7e59d29330a8265df5cbeR211-R232): Added a new `testableGetRandomOTP` method for testing purposes, and updated the `_getRandomOTP` method to support different OTP types (alpha, alphaNumeric, numeric) and lengths.

Additions to test cases:

* [`test/_test.dart`](diffhunk://#diff-26ccea26e969deac2dbfc44e321cfd5f6c64ddfa3eb302afe359cd03185a5392R29-R65): Added a new test group for the `getRandomOTP` method, including tests to verify OTP length, numeric OTP generation, and uniqueness of generated OTPs.